### PR TITLE
separate the subnets used by master and worker nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ module "eks" {
 | tfstate\_global\_bucket | S3 where the remote state is stored | string | n/a | yes |
 | vpc\_name | VPC Name | string | n/a | yes |
 | vpc\_state\_key | Key where the vpc remote state is stored | string | `"vpc"` | no |
+| vpc_id | VPC ID | string | n/a | yes |
+| master_subnets_ids | Subnets used by master nodes | `list(list(string))` | `[["a1", "a2"], ["b1", "b2"]]` | yes |
+| worker_private_subnets_ids | Private subnets used by worker nodes | `list(string)` | `["a1", "a2"]` | yes |
+| worker_public_subnets_ids | Public subnets used by worker nodes | `list(string)` | `["a1", "a2"]` | yes |
+| worker_intra_subnets_ids | Intra subnets used by worker nodes | `list(string)` | `["a1", "a2"]` | yes |
 | worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | list | `[]]` | no |
 | write\_aws\_auth\_config | Whether to write the aws-auth configmap file. | bool | `"true"` | no |
 | write\_kubeconfig | Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`. | bool | `"true"` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -129,6 +129,30 @@ variable "vpc_name" {
   description = "VPC Name"
 }
 
+variable "vpc_id" {
+  description = "VPC ID"
+}
+
+variable "master_subnets_ids" {
+  description = "Subnets used by EKS master nodes"
+  type        = list(list(string))
+}
+
+variable "worker_public_subnets_ids" {
+  description = "Public subnets used by worker nodes"
+  type        = set(string)
+}
+
+variable "worker_private_subnets_ids" {
+  description = "Private subnets used by worker nodes"
+  type        = set(string)
+}
+
+variable "worker_intra_subnets_ids" {
+  description = "Intra subnets used by worker nodes"
+  type        = set(string)
+}
+
 variable "config_output_path" {
   description = "Where to save the Kubectl config file (if `write_kubeconfig = true`). Should end in a forward slash `/` ."
   type        = string


### PR DESCRIPTION
this change requires the users to provide the vpc_id and subnet_ids
- vpc_id
- master_subnets_ids
- private_subnets_ids
- public_subnets_ids
- intra_subnets_ids