### PR TITLE
Fixes: Added CloudWatchAgentServerPolicy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ module "eks" {
 
   workers_additional_policies = concat(
     var.enable_dynamic_pv ? aws_iam_policy.dynamic-persistent-volume-provisioning.*.arn : [],
-    var.enable_ssm ? ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"] : []
+    var.enable_ssm ? ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore","arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"] : []
   )
   worker_additional_security_group_ids = var.worker_additional_security_group_ids
 


### PR DESCRIPTION
I have added CloudWatchAgentServerPolicy when the SSM variable is set to true this will allow SSM innovation on the EC2 instance to write to the necessary cloud watch log groups.