### PR TITLE
fixes: adding a new policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,8 @@ module "eks" {
 
   workers_additional_policies = concat(
     var.enable_dynamic_pv ? aws_iam_policy.dynamic-persistent-volume-provisioning.*.arn : [],
-    var.enable_ssm ? ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore","arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"] : []
+    var.enable_ssm ? ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore","arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"] : [],
+    "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
   )
   worker_additional_security_group_ids = var.worker_additional_security_group_ids
 


### PR DESCRIPTION
Adding a new policy is required when we add the new add-on `AWS EBS CSI Driver` in EKS console.
https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html

Changes in the variable, workers_additional_policies at line 80.