### PR TITLE
chores: fixing workers_additional_policies 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ module "eks" {
   workers_additional_policies = concat(
     var.enable_dynamic_pv ? aws_iam_policy.dynamic-persistent-volume-provisioning.*.arn : [],
     var.enable_ssm ? ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore","arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"] : [],
-    "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+    ["arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"]
   )
   worker_additional_security_group_ids = var.worker_additional_security_group_ids
 


### PR DESCRIPTION
Fixing the mistake of using a string in concat function for variables, workers_additional_policies in line 83.